### PR TITLE
Disable `updateSinceUntilBuild` to allow idea upgrades without recompilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ intellij {
     version idea_version
     downloadSources false
     plugins 'kotlin'
+    // Don't require recompilation for every idea release
+    updateSinceUntilBuild false
 
     // https://plugins.jetbrains.com/plugin/6954-kotlin
     plugins = ['org.jetbrains.kotlin:1.3.21-release-IJ2018.3-1']


### PR DESCRIPTION
It's relatively infrequent that we have to update the plugin
implementation. This flag allows us to upgrade idea without rebuilding
jitwatch-idea, however it is possible that eventual ABI breaks will
cause the plugin to fail.